### PR TITLE
Fixes to invalid item IDs

### DIFF
--- a/src/main/resources/data/pandamc_concreteplus/loot_tables/blocks/cyan_concrete_stairs.json
+++ b/src/main/resources/data/pandamc_concreteplus/loot_tables/blocks/cyan_concrete_stairs.json
@@ -9,7 +9,7 @@
       "entries": [
         {
           "type": "minecraft:item",
-          "name": "pandacp:cyan_concrete_stairs"
+          "name": "pandamc_concreteplus:cyan_concrete_stairs"
         }
       ],
       "conditions": [

--- a/src/main/resources/data/pandamc_concreteplus/loot_tables/blocks/light_gray_concrete_slab.json
+++ b/src/main/resources/data/pandamc_concreteplus/loot_tables/blocks/light_gray_concrete_slab.json
@@ -24,7 +24,7 @@
                 "function": "minecraft:explosion_decay"
               }
             ],
-            "name": "pandacp:light_gray_concrete_slab"
+            "name": "pandamc_concreteplus:light_gray_concrete_slab"
           }
         ]
       }

--- a/src/main/resources/data/pandamc_concreteplus/loot_tables/blocks/magenta_concrete_slab.json
+++ b/src/main/resources/data/pandamc_concreteplus/loot_tables/blocks/magenta_concrete_slab.json
@@ -24,7 +24,7 @@
                 "function": "minecraft:explosion_decay"
               }
             ],
-            "name": "pandacp:magenta_concrete_slab"
+            "name": "pandamc_concreteplus:magenta_concrete_slab"
           }
         ]
       }


### PR DESCRIPTION
These 3 blocks had broken loot tables, making them drop nothing